### PR TITLE
feat(life-cycle): Add init lifecycle event.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "peerDependencies": {
     "karma": "^0.13.0 || 1.0.0",
     "karma-coverage": "^0.5.5 || ^1.0.0",
-    "stryker-api": "^0.1.0"
+    "stryker-api": "^0.1.1"
   },
   "devDependencies": {
     "chai": "^3.5.0",
@@ -42,7 +42,7 @@
     "karma-jasmine": "^1.0.2",
     "karma-phantomjs-launcher": "^1.0.1",
     "mocha": "^2.5.3",
-    "stryker-api": "^0.1.0",
+    "stryker-api": "^0.1.1",
     "typescript": "^1.8.10",
     "typings": "^1.3.0"
   },

--- a/test/integration/KarmaTestRunnerSpec.ts
+++ b/test/integration/KarmaTestRunnerSpec.ts
@@ -7,7 +7,7 @@ import * as chaiAsPromised from 'chai-as-promised';
 chai.use(chaiAsPromised);
 let expect = chai.expect;
 
-describe('KarmaTestRunner', function() {
+describe('KarmaTestRunner', function () {
 
   var sut: KarmaTestRunner;
   this.timeout(10000);
@@ -28,6 +28,7 @@ describe('KarmaTestRunner', function() {
 
       before(() => {
         sut = new KarmaTestRunner(testRunnerOptions);
+        return sut.init();
       });
 
       it('should report completed tests with code coverage', () => {
@@ -64,6 +65,7 @@ describe('KarmaTestRunner', function() {
 
       before(() => {
         sut = new KarmaTestRunner(testRunnerOptions);
+        return sut.init();
       });
 
       it('should report completed tests without coverage', () => {
@@ -88,6 +90,7 @@ describe('KarmaTestRunner', function() {
         strykerOptions: {}
       };
       sut = new KarmaTestRunner(testRunnerOptions);
+      return sut.init();
     });
 
     it('should report Error with the error message', () => {
@@ -111,6 +114,7 @@ describe('KarmaTestRunner', function() {
         strykerOptions: {}
       };
       sut = new KarmaTestRunner(testRunnerOptions);
+      return sut.init();
     });
 
     it('should report Complete without errors', () => {


### PR DESCRIPTION
During init, we will wait for karma to become ready, i.e. when the `browsers_ready` event is thrown.