### PR TITLE
feat(stop-karma): Stop karma on dispose

### DIFF
--- a/src/KarmaTestRunner.ts
+++ b/src/KarmaTestRunner.ts
@@ -72,6 +72,10 @@ export default class KarmaTestRunner extends EventEmitter implements TestRunner 
     return this.runServer().then(() => this.collectRunResult());
   }
 
+  dispose(): Promise<void> {
+    return this.stopServer();
+  }
+
   // Don't use dispose() to stop karma (using karma.stopper.stop)
   // It only works when in `detached` mode, as specified here: http://karma-runner.github.io/1.0/config/configuration-file.html
 
@@ -164,8 +168,17 @@ export default class KarmaTestRunner extends EventEmitter implements TestRunner 
     return karmaConfig;
   }
 
+  private stopServer() {
+    return new Promise<void>(resolve => {
+      karma.stopper.stop({ port: this.options.port }, exitCode => {
+        log.info('karma stopped on command with %s', exitCode);
+        resolve();
+      });
+    });
+  }
+
   private runServer() {
-    return new Promise<void>((resolve) => {
+    return new Promise<void>(resolve => {
       karma.runner.run({ port: this.options.port }, (exitCode) => {
         log.info('karma run done with ', exitCode);
         resolve();

--- a/test/helpers/chaiSetup.ts
+++ b/test/helpers/chaiSetup.ts
@@ -1,3 +1,5 @@
 import * as chai from 'chai';
 import * as sinonChai from 'sinon-chai';
+import * as chaiAsPromised from 'chai-as-promised';
 chai.use(sinonChai);
+chai.use(chaiAsPromised);

--- a/test/integration/KarmaTestRunner.it.ts
+++ b/test/integration/KarmaTestRunner.it.ts
@@ -1,9 +1,6 @@
-import * as chai from 'chai';
-import KarmaTestRunner from '../../src/KarmaTestRunner';
+import { expect } from 'chai';
 import { CoverageCollection, RunnerOptions, RunResult, RunStatus, TestStatus } from 'stryker-api/test_runner';
-import * as chaiAsPromised from 'chai-as-promised';
-chai.use(chaiAsPromised);
-let expect = chai.expect;
+import KarmaTestRunner from '../../src/KarmaTestRunner';
 
 describe('KarmaTestRunner', function () {
 


### PR DESCRIPTION
Stop karma on dispose using the new `karma.stopper.stop` api. Only resolve the promise if it stopped.