### PR TITLE
feat(KarmaTestRunner): Force cwd as basePath

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "sinon-chai": "^2.8.0",
     "stryker-api": "^0.4.2-rc0",
     "tslint": "^4.0.2",
-    "typescript": "^2.1.4"
+    "typescript": "^2.2.1"
   },
   "dependencies": {
     "lodash": "^4.13.1",

--- a/src/KarmaTestRunner.ts
+++ b/src/KarmaTestRunner.ts
@@ -7,7 +7,7 @@ import * as rawCoverageReporter from './RawCoverageReporter';
 
 const log = log4js.getLogger('KarmaTestRunner');
 
-interface ConfigOptions extends karma.ConfigOptions {
+export interface ConfigOptions extends karma.ConfigOptions {
   coverageReporter?: { type: string, dir?: string, subdir?: string };
   detached?: boolean;
 }
@@ -22,13 +22,26 @@ interface KarmaSpec {
   log: string[];
 }
 
-const DEFAULT_OPTIONS: ConfigOptions = {
+const FORCED_OPTIONS = (() => {
+  const config: ConfigOptions = {
+    // Override browserNoActivityTimeout. Default value 10000 might not enough to send perTest coverage results
+    browserNoActivityTimeout: 1000000,
+    // Override base, we don't want to original karma baseDir to be interfering with the stryker setup
+    basePath: '.',
+    // No auto watch, stryker will inform us when we need to test
+    autoWatch: false,
+    // Don't stop after first run
+    singleRun: false,
+    // Never detach, always run in this same process (is already a separate process)
+    detached: false
+  };
+  return Object.freeze(config);
+})();
+
+const DEFAULT_OPTIONS: Readonly<ConfigOptions> = Object.freeze({
   browsers: ['PhantomJS'],
   frameworks: ['jasmine'],
-  autoWatch: false,
-  singleRun: false,
-  detached: false
-};
+});
 
 export default class KarmaTestRunner extends EventEmitter implements TestRunner {
 
@@ -153,8 +166,7 @@ export default class KarmaTestRunner extends EventEmitter implements TestRunner 
     // Override port
     karmaConfig.port = this.options.port;
 
-    // Override browserNoActivityTimeout. Default value 10000 might not enough to send perTest coverage results
-    karmaConfig.browserNoActivityTimeout = 1000000;
+    this.forceOptions(karmaConfig);
 
     // Override frameworks
     if (this.options.strykerOptions.testFramework && !(overrides && overrides.frameworks)) {
@@ -162,6 +174,13 @@ export default class KarmaTestRunner extends EventEmitter implements TestRunner 
     }
 
     return karmaConfig;
+  }
+
+  private forceOptions(karmaConfig: ConfigOptions) {
+    let i: keyof ConfigOptions;
+    for (i in FORCED_OPTIONS) {
+      karmaConfig[i] = FORCED_OPTIONS[i];
+    }
   }
 
   private runServer() {

--- a/test/unit/KarmaTestRunnerSpec.ts
+++ b/test/unit/KarmaTestRunnerSpec.ts
@@ -1,3 +1,4 @@
+import { ConfigOptions } from './../../src/KarmaTestRunner';
 import { expect } from 'chai';
 import KarmaTestRunner from '../../src/KarmaTestRunner';
 import { RunnerOptions } from 'stryker-api/test_runner';
@@ -23,6 +24,25 @@ describe('KarmaTestRunner', () => {
   });
 
   describe('when constructed', () => {
+
+    it('should force some non-overridable options', () => {
+      const karmaConfig: ConfigOptions = {
+        browserNoActivityTimeout: 100,
+        basePath: '../',
+        autoWatch: true,
+        singleRun: true,
+        detached: true
+      };
+      options.strykerOptions.karmaConfig = karmaConfig;
+      new KarmaTestRunner(options);
+      expect(karma.Server).to.have.been.calledWith(sinon.match({
+        browserNoActivityTimeout: 1000000,
+        basePath: '.',
+        autoWatch: false,
+        singleRun: false,
+        detached: false
+      }));
+    });
 
     describe('and no testFramework is supplied', () => {
       beforeEach(() => sut = new KarmaTestRunner(options));


### PR DESCRIPTION
Force the current working directory as karma `basePath` during test runs. An other base path to run karma from doesn't make sense when running in a stryker sandbox.